### PR TITLE
Fix tanh backward derivative

### DIFF
--- a/KoTanh.cpp
+++ b/KoTanh.cpp
@@ -9,9 +9,9 @@ NDArray KoTanh::Forward(const NDArrays& inputs)
 
 NDArrays KoTanh::Backward(const NDArray& gradient,const NDArrays& inputs)
 {
-	return
-	{
-		// Differental of tanh(x) WRT x is 1-tanh(x)^2, multiply this by the gradient and backprop.
-		(gradient.Ones()-(inputs[0]*inputs[0]))*gradient
-	};
+        return
+        {
+                // Differential of tanh(x) WRT x is 1 - tanh(x)^2; multiply this by the gradient and backprop.
+                (gradient.Ones()-(inputs[0].Tanh()*inputs[0].Tanh()))*gradient
+        };
 }


### PR DESCRIPTION
## Summary
- Compute tanh derivative using tanh(x)^2 rather than x^2 in KoTanh backward implementation

## Testing
- `g++ -std=c++17 -pthread *.cpp -o AutoGrad_test` (fails: concurrent_queue.h: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689b4019857c8325a9d1e595d9bb87f1